### PR TITLE
Add support for specifying part sizes and stdin as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Work with huge numbers of small files more quickly.
 
 ### 1. Safely split a large tar archive into a specified number of smaller tar archives
 
-- `i` - input tar archive that you want to split
+- `i` - input tar file that you want to split, or '-' to read from stdin
 - `o` - output pattern
 - `p` - number of smaller archives to split the input archive into
+- `s` - maximum size of each tar file, e.g. '100MB', '4G'
 
 ```bash
 tarsplitter -m split -i archive.tar -o /tmp/archive-parts -p 4
@@ -37,6 +38,20 @@ Processed files= 120000
 Done reading input archive
 All done
 ```
+
+If input is specified as '-', the archive will be read from stdin,
+which allows piping directly from tar(1) to tarsplitter. This scenario
+is only useful with the `-s` option to specify the maximum individual
+part size.
+
+For example:
+```bash
+tar -cvf - . | tarsplitter -i - -s 1G -o /tmp/archive-
+```
+This will create tar files that are at most 1GB in size, though
+individual sizes will vary depending on the input files and how they're
+sorted.
+
 
 ### 2. Multitheaded Archiving
 

--- a/tarsplitter.go
+++ b/tarsplitter.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"github.com/c2h5oh/datasize"
 )
 
 var input = flag.String("i", "", "input archive file for splitting, OR input directory for archiving")
@@ -18,6 +19,8 @@ var command = flag.String("m", "split", "input mode command - must be 'split' or
 var output = flag.String("o", "", "output path or folder")
 var partCount = flag.Int64("p", 4, "number of parts to split the archive into, or number of threads when archiving")
 var fileList = flag.String("f", "", "optional list of files instead of input for archiving")
+var partSize = flag.String("s", "", "approximate size of each part, e.g. '100MB', '4G'")
+
 
 func fatalIf(err error, args ...interface{}) {
 	if err != nil {
@@ -54,17 +57,31 @@ func doSplit() {
 		os.Exit(1)
 	}
 
-	file, err := os.Open(*input)
-	fatalIf(err, "Failed statting input", *input)
-	defer file.Close()
+	var file io.Reader
+	var partSizeBytes int64
 
-	// get the file size
-	stat, err := file.Stat()
-	fatalIf(err, "Failed statting input", *input)
+	if *input == "-" {
+		file = os.Stdin
+		var size datasize.ByteSize
+		_ = size.UnmarshalText([]byte(*partSize))
+		partSizeBytes = int64(size.Bytes())
 
-	partSizeBytes := stat.Size() / *partCount
-	fmt.Println(stat.Name(), "is", stat.Size(), "bytes, splitting into", *partCount, "parts of",
-		partSizeBytes, "bytes")
+		if partSizeBytes == 0 {
+			partSizeBytes = math.MaxInt64
+		}
+	} else {
+		file, err := os.Open(*input)
+		fatalIf(err, "Failed statting input", *input)
+		defer file.Close()
+
+		// get the file size
+		stat, err := file.Stat()
+		fatalIf(err, "Failed statting input", *input)
+
+		partSizeBytes := stat.Size() / *partCount
+		fmt.Println(stat.Name(), "is", stat.Size(), "bytes, splitting into", *partCount, "parts of",
+			partSizeBytes, "bytes")
+	}
 
 	// now we get to work
 	var info *tar.Header
@@ -97,24 +114,8 @@ func doSplit() {
 		// add the file from the original archive to the new archive
 		tempInfo, _ = newTarFile.Stat()
 		bytesBeforeWrite = tempInfo.Size()
-		err = newTar.WriteHeader(info)
-		fatalIf(err, "failed writing header between tars")
 
-		// write from the reader
-		_, err = io.Copy(newTar, tr)
-		fatalIf(err, "failed writing file body between tars")
-
-		filesProcessed++
-		if filesProcessed%10000 == 0 {
-			fmt.Println("Processed files=", filesProcessed)
-		}
-
-		tempInfo, _ = newTarFile.Stat()
-		bytesAfterWrite = tempInfo.Size()
-
-		byteCounter += bytesAfterWrite - bytesBeforeWrite
-
-		if byteCounter > partSizeBytes {
+		if (bytesBeforeWrite + info.Size > partSizeBytes || byteCounter > partSizeBytes) {
 			byteCounter = 0
 			newTarCounter++
 
@@ -131,6 +132,23 @@ func doSplit() {
 			newTar = tar.NewWriter(newTarFile)
 
 			fmt.Println("Initialized next tar archive", newTarFile.Name())
+		} else {
+			err = newTar.WriteHeader(info)
+			fatalIf(err, "failed writing header between tars")
+
+			// write from the reader
+			_, err = io.Copy(newTar, tr)
+			fatalIf(err, "failed writing file body between tars")
+
+			filesProcessed++
+			if filesProcessed%10000 == 0 {
+				fmt.Println("Processed files=", filesProcessed)
+			}
+
+			tempInfo, _ = newTarFile.Stat()
+			bytesAfterWrite = tempInfo.Size()
+
+			byteCounter += bytesAfterWrite - bytesBeforeWrite
 		}
 	}
 }


### PR DESCRIPTION
Hi, thanks for this great tool.

I took a stab at addressing #1 to allow piping directly to tarsplitter from tar itself when input is specified as '-', which avoids the need for a large intermediary tar file. For example: `tar -cvf - . | tarsplitter -i - -s 1G -o /tmp/archive-`. This will create tar files that are at most 1GB in size, though individual sizes will vary depending on the input files and how they're sorted.

This comes at a cost of an external dependency (https://github.com/c2h5oh/datasize), but I hope you'll agree that it's best to not reinvent the wheel for parsing human-readable sizes.

The `-p` option doesn't make sense when input is stdin since we can't know the total input size in advance to calculate the part size. Similarly, if `-s` is not provided when input is stdin no splitting will occur and in both cases only a single tar file will be created, which defeats the purpose of using tarsplitter, so the user should ensure to always specify `-s` with `-i -`. Maybe we should enforce this explicitly, but I didn't think it was necessary.

On a separate note, I didn't test this with `-m archive`, which I think should be removed from tarsplitter, leaving this functionality to tar itself now that stdin is supported. I would also consider deprecating `-p` since the user usually wants control over the part size and not the quantity of files produced.

Ideally we should have unit/functional tests for all this, but I'll leave that for another PR. :)

Cheers,

Ivan